### PR TITLE
Better hi parsing

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -4,11 +4,8 @@ function! s:get_sign_ctermbg()
         silent hi SignColumn
     redir END
 
-    let index = match(sign_col, 'ctermbg')
     "may return values like 'ctermbg=8' or 'ctermbg=256'
-    let ctermbg_str = matchstr(sign_col, 'ctermbg=\d\+')
-    let val_len = strlen(ctermbg_str) - 8
-    let ctermbg = strpart(sign_col, index + 8, val_len)
+    let ctermbg = matchlist(sign_col, 'ctermbg=\(\d\+\)')[1]
     return ctermbg
 endfunction
 
@@ -19,8 +16,7 @@ function! s:get_sign_guibg()
         silent hi SignColumn
     redir END
 
-    let index = match(sign_col, 'guibg')
-    let guibg = strpart(sign_col, index + 6, 7)
+    let guibg = matchlist(sign_col, 'guibg=\([^ ]\+\)')[1]
     return guibg
 endfunction
 


### PR DESCRIPTION
Previous code set some expectations on the highlight command output which not
always are true. It exptected `ctermbg` to be exactly 3 chars long and `guibg`
to be exactly 7 chars long. This is not true for many cases. Here's for example
my `SingColumn`:

```
SignColumn     xxx term=standout ctermfg=11 ctermbg=8 guifg=Cyan guibg=Grey
```

New code sets a different sets of expectations that might be a bit better. New
code relies on the normalized output of `highlight` command. It parses output
and takes the part from "=" to the first space. This should cover the case of
varying length of numeric colours as well as named colours.
